### PR TITLE
Add `literal`

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ yarn add facepaint
 
 ## API
 
-#### facepaint `function` 
+#### facepaint `function`
 
 ```javascript
 facepaint(selectors: Array<Selector>) : DynamicStyleFunction
@@ -46,23 +46,27 @@ facepaint(selectors: Array<Selector>) : DynamicStyleFunction
     '@media(min-width: 1120px)'
   ])
   ```
-  
+
 * *options*
   ```javascript
   const mq = facepaint(
-    [...], 
-    { overlap: true|false }
+    [...],
+    {
+      literal: true|false,
+      overlap: true|false
+    }
   )
   ```
+  - literal `boolean` (Default: `false`) - force "slot"
   - overlap `boolean` (Default: `false`) - remove any duplicate values found in multiple "slots"
 
 **Returns**
 
 `facepaint` returns a function that can be exported and used throughout
-your app to dynamically style based on your provided selectors. 
+your app to dynamically style based on your provided selectors.
 
 - The function accepts any number of arrays or objects as arguments.
-- Nested arrays are flattened. 
+- Nested arrays are flattened.
 - Boolean, `undefined`, and `null` values are ignored.
 
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-param-reassign */
-export default function(breakpoints, { overlap } = {}) {
-  const mq = [''].concat(breakpoints)
+export default function(breakpoints, { literal, overlap } = {}) {
+  const mq = literal ? breakpoints : [''].concat(breakpoints)
   function flatten(obj) {
     if (typeof obj !== 'object' || obj == null) {
       return []
@@ -13,9 +13,13 @@ export default function(breakpoints, { overlap } = {}) {
     return Object.keys(obj).reduce((slots, key) => {
       // Check if value is an array, but skip if it looks like a selector.
       // key.indexOf('&') === 0
-      if (Array.isArray(obj[key]) && key.charCodeAt(0) !== 38) {
+
+      let item = obj[key]
+      if (!Array.isArray(item) && literal) item = [item]
+
+      if ((literal || Array.isArray(item)) && key.charCodeAt(0) !== 38) {
         let prior
-        obj[key].forEach((v, index) => {
+        item.forEach((v, index) => {
           // Optimize by removing duplicated media query entries
           // when they are explicitly known to overlap.
           if (overlap && prior === v) {
@@ -30,7 +34,7 @@ export default function(breakpoints, { overlap } = {}) {
 
           prior = v
 
-          if (index === 0) {
+          if (index === 0 && !literal) {
             slots[key] = v
           } else if (!slots[mq[index]]) {
             slots[mq[index]] = { [key]: v }
@@ -38,10 +42,10 @@ export default function(breakpoints, { overlap } = {}) {
             slots[mq[index]][key] = v
           }
         })
-      } else if (typeof obj[key] === 'object') {
-        slots[key] = flatten(obj[key])
+      } else if (typeof item === 'object') {
+        slots[key] = flatten(item)
       } else {
-        slots[key] = obj[key]
+        slots[key] = item
       }
       return slots
     }, {})

--- a/test/__snapshots__/index.test.js.snap
+++ b/test/__snapshots__/index.test.js.snap
@@ -1,671 +1,121 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`facepaint array values with selectors 1`] = `"css-1ot4erq"`;
+exports[`facepaint literal 1 1`] = `"css-1n438h9"`;
 
-exports[`facepaint array values with selectors 2`] = `
-.glamor-0 .current-index {
-  color: blue;
-  margin-right: 15px;
-  display: none;
-  -webkit-letter-spacing: 3px;
-  -moz-letter-spacing: 3px;
-  -ms-letter-spacing: 3px;
-  letter-spacing: 3px;
-}
-
+exports[`facepaint literal 1 2`] = `
 @media (min-width:420px) {
-  .glamor-0 .current-index {
-    color: red;
-  }
-}
-
-@media (min-width:420px) {
-  .glamor-0 .current-index {
-    display: block;
+  .glamor-0 {
+    background: red;
   }
 }
 
 <div
   className="glamor-0"
 >
-  <div
-    className="foo"
-  >
-    foo
-  </div>
-  function
+  foo
 </div>
 `;
 
-exports[`facepaint array values with selectors 3`] = `
-".css-1ot4erq .current-index {
-  color: blue;
-  margin-right: 15px;
-  display: none;
-  -webkit-letter-spacing: 3px;
-  -moz-letter-spacing: 3px;
-  -ms-letter-spacing: 3px;
-  letter-spacing: 3px;
-}
-
-@media (min-width:420px) {
-  .css-1ot4erq .current-index {
-    color: red;
-  }
-}
-
-@media (min-width:420px) {
-  .css-1ot4erq .current-index {
-    display: block;
+exports[`facepaint literal 1 3`] = `
+"@media (min-width:420px) {
+  .css-1n438h9 {
+    background: red;
   }
 }"
 `;
 
-exports[`facepaint basic 1`] = `"css-xee1ha"`;
+exports[`facepaint literal 2 1`] = `"css-1k7f7mv"`;
 
-exports[`facepaint basic 2`] = `
-.glamor-0 {
-  color: red;
-}
-
+exports[`facepaint literal 2 2`] = `
 @media (min-width:420px) {
   .glamor-0 {
-    color: green;
+    background: red;
   }
 }
 
 @media (min-width:920px) {
   .glamor-0 {
-    color: blue;
-  }
-}
-
-@media (min-width:1120px) {
-  .glamor-0 {
-    color: darkorchid;
+    background: green;
   }
 }
 
 <div
   className="glamor-0"
 >
-  Basic
+  foo
 </div>
 `;
 
-exports[`facepaint basic 3`] = `
-".css-xee1ha {
-  color: red;
-}
-
-@media (min-width:420px) {
-  .css-xee1ha {
-    color: green;
+exports[`facepaint literal 2 3`] = `
+"@media (min-width:420px) {
+  .css-1k7f7mv {
+    background: red;
   }
 }
 
 @media (min-width:920px) {
-  .css-xee1ha {
-    color: blue;
-  }
-}
-
-@media (min-width:1120px) {
-  .css-xee1ha {
-    color: darkorchid;
+  .css-1k7f7mv {
+    background: green;
   }
 }"
 `;
 
-exports[`facepaint boolean, null, and undefined values 1`] = `"css-dhb7kq"`;
+exports[`facepaint literal all 1`] = `"css-1ahnw43"`;
 
-exports[`facepaint boolean, null, and undefined values 2`] = `
-.glamor-0 {
-  color: blue;
-  color: red;
-}
-
-<div
-  className="glamor-0"
->
-  <div
-    className="foo"
-  >
-    foo
-  </div>
-  function
-</div>
-`;
-
-exports[`facepaint boolean, null, and undefined values 3`] = `
-".css-dhb7kq {
-  color: blue;
-  color: red;
-}"
-`;
-
-exports[`facepaint holes 1`] = `"css-196uzh"`;
-
-exports[`facepaint holes 2`] = `
-.glamor-0 {
-  color: red;
+exports[`facepaint literal all 2`] = `
+@media (min-width:420px) {
+  .glamor-0 {
+    background: red;
+  }
 }
 
 @media (min-width:920px) {
   .glamor-0 {
-    color: blue;
+    background: green;
   }
 }
 
 @media (min-width:1120px) {
   .glamor-0 {
-    color: darkorchid;
-  }
-}
-
-<div
-  className="glamor-0"
->
-  Basic
-</div>
-`;
-
-exports[`facepaint holes 3`] = `
-".css-196uzh {
-  color: red;
-}
-
-@media (min-width:920px) {
-  .css-196uzh {
-    color: blue;
-  }
-}
-
-@media (min-width:1120px) {
-  .css-196uzh {
-    color: darkorchid;
-  }
-}"
-`;
-
-exports[`facepaint multiple 1`] = `"css-egce6e"`;
-
-exports[`facepaint multiple 2`] = `
-.glamor-0 {
-  color: red;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  font-size: 12px;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-@media (min-width:420px) {
-  .glamor-0 {
-    color: green;
-    display: block;
-  }
-}
-
-@media (min-width:920px) {
-  .glamor-0 {
-    color: blue;
-    display: inline-block;
-  }
-}
-
-@media (min-width:1120px) {
-  .glamor-0 {
-    color: darkorchid;
-    display: table;
-  }
-}
-
-<div
-  className="glamor-0"
->
-  multiple
-</div>
-`;
-
-exports[`facepaint multiple 3`] = `
-".css-egce6e {
-  color: red;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  font-size: 12px;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-@media (min-width:420px) {
-  .css-egce6e {
-    color: green;
-    display: block;
-  }
-}
-
-@media (min-width:920px) {
-  .css-egce6e {
-    color: blue;
-    display: inline-block;
-  }
-}
-
-@media (min-width:1120px) {
-  .css-egce6e {
-    color: darkorchid;
-    display: table;
-  }
-}"
-`;
-
-exports[`facepaint nested 1`] = `"css-rbuh8g"`;
-
-exports[`facepaint nested 2`] = `
-.glamor-0 {
-  background-color: hotpink;
-  text-align: center;
-  width: 25%;
-}
-
-.glamor-0 .foo {
-  color: red;
-}
-
-.glamor-0 .foo img {
-  height: 10px;
-}
-
-@media (min-width:420px) {
-  .glamor-0 {
-    width: 50%;
-  }
-}
-
-@media (min-width:920px) {
-  .glamor-0 {
-    width: 75%;
-  }
-}
-
-@media (min-width:1120px) {
-  .glamor-0 {
-    width: 100%;
-  }
-}
-
-@media (min-width:420px) {
-  .glamor-0 .foo {
-    color: green;
-  }
-}
-
-@media (min-width:920px) {
-  .glamor-0 .foo {
-    color: blue;
-  }
-}
-
-@media (min-width:1120px) {
-  .glamor-0 .foo {
-    color: darkorchid;
-  }
-}
-
-@media (min-width:420px) {
-  .glamor-0 .foo img {
-    height: 15px;
-  }
-}
-
-@media (min-width:920px) {
-  .glamor-0 .foo img {
-    height: 20px;
-  }
-}
-
-@media (min-width:1120px) {
-  .glamor-0 .foo img {
-    height: 25px;
-  }
-}
-
-<div
-  className="glamor-0"
->
-  <div
-    className="foo"
-  >
-    foo
-  </div>
-  function
-</div>
-`;
-
-exports[`facepaint nested 3`] = `
-".css-rbuh8g {
-  background-color: hotpink;
-  text-align: center;
-  width: 25%;
-}
-
-@media (min-width:420px) {
-  .css-rbuh8g {
-    width: 50%;
-  }
-}
-
-@media (min-width:920px) {
-  .css-rbuh8g {
-    width: 75%;
-  }
-}
-
-@media (min-width:1120px) {
-  .css-rbuh8g {
-    width: 100%;
-  }
-}
-
-.css-rbuh8g .foo {
-  color: red;
-}
-
-@media (min-width:420px) {
-  .css-rbuh8g .foo {
-    color: green;
-  }
-}
-
-@media (min-width:920px) {
-  .css-rbuh8g .foo {
-    color: blue;
-  }
-}
-
-@media (min-width:1120px) {
-  .css-rbuh8g .foo {
-    color: darkorchid;
-  }
-}
-
-.css-rbuh8g .foo img {
-  height: 10px;
-}
-
-@media (min-width:420px) {
-  .css-rbuh8g .foo img {
-    height: 15px;
-  }
-}
-
-@media (min-width:920px) {
-  .css-rbuh8g .foo img {
-    height: 20px;
-  }
-}
-
-@media (min-width:1120px) {
-  .css-rbuh8g .foo img {
-    height: 25px;
-  }
-}"
-`;
-
-exports[`facepaint nested arrays 1`] = `"css-1faqh3h"`;
-
-exports[`facepaint nested arrays 2`] = `
-.glamor-0 {
-  color: red;
-}
-
-@media (min-width:420px) {
-  .glamor-0 {
-    color: blue;
-  }
-}
-
-@media (min-width:920px) {
-  .glamor-0 {
-    color: darkorchid;
-  }
-}
-
-<div
-  className="glamor-0"
->
-  Basic
-</div>
-`;
-
-exports[`facepaint nested arrays 3`] = `
-".css-1faqh3h {
-  color: red;
-}
-
-@media (min-width:420px) {
-  .css-1faqh3h {
-    color: blue;
-  }
-}
-
-@media (min-width:920px) {
-  .css-1faqh3h {
-    color: darkorchid;
-  }
-}"
-`;
-
-exports[`facepaint pseudo 1`] = `"css-1guvnfu"`;
-
-exports[`facepaint pseudo 2`] = `
-.glamor-0 {
-  background-color: hotpink;
-  text-align: center;
-  width: 25%;
-}
-
-.glamor-0:hover {
-  width: 50%;
-}
-
-.glamor-0:active {
-  width: 75%;
-}
-
-.glamor-0:focus {
-  width: 100%;
-}
-
-.glamor-0 .foo {
-  color: red;
-}
-
-.glamor-0 .foo:hover {
-  color: green;
-}
-
-.glamor-0 .foo:active {
-  color: blue;
-}
-
-.glamor-0 .foo:focus {
-  color: darkorchid;
-}
-
-.glamor-0 .foo img {
-  height: 10px;
-}
-
-.glamor-0 .foo img:hover {
-  height: 15px;
-}
-
-.glamor-0 .foo img:active {
-  height: 20px;
-}
-
-.glamor-0 .foo img:focus {
-  height: 25px;
-}
-
-<div
-  className="glamor-0"
->
-  <div
-    className="foo"
-  >
-    foo
-  </div>
-  function
-</div>
-`;
-
-exports[`facepaint pseudo 3`] = `
-".css-1guvnfu {
-  background-color: hotpink;
-  text-align: center;
-  width: 25%;
-}
-
-.css-1guvnfu:hover {
-  width: 50%;
-}
-
-.css-1guvnfu:active {
-  width: 75%;
-}
-
-.css-1guvnfu:focus {
-  width: 100%;
-}
-
-.css-1guvnfu .foo {
-  color: red;
-}
-
-.css-1guvnfu .foo:hover {
-  color: green;
-}
-
-.css-1guvnfu .foo:active {
-  color: blue;
-}
-
-.css-1guvnfu .foo:focus {
-  color: darkorchid;
-}
-
-.css-1guvnfu .foo img {
-  height: 10px;
-}
-
-.css-1guvnfu .foo img:hover {
-  height: 15px;
-}
-
-.css-1guvnfu .foo img:active {
-  height: 20px;
-}
-
-.css-1guvnfu .foo img:focus {
-  height: 25px;
-}"
-`;
-
-exports[`facepaint repeating 1`] = `"css-nhhz1q"`;
-
-exports[`facepaint repeating 2`] = `
-.glamor-0 {
-  color: red;
-}
-
-@media (min-width:420px) {
-  .glamor-0 {
-    color: blue;
+    background: blue;
   }
 }
 
 @media (min-width:11200px) {
   .glamor-0 {
-    color: darkorchid;
+    background: orange;
   }
 }
 
 <div
   className="glamor-0"
 >
-  Basic
+  foo
 </div>
 `;
 
-exports[`facepaint repeating 3`] = `
-".css-nhhz1q {
-  color: red;
+exports[`facepaint literal all 3`] = `
+"@media (min-width:420px) {
+  .css-1ahnw43 {
+    background: red;
+  }
 }
 
-@media (min-width:420px) {
-  .css-nhhz1q {
-    color: blue;
+@media (min-width:920px) {
+  .css-1ahnw43 {
+    background: green;
+  }
+}
+
+@media (min-width:1120px) {
+  .css-1ahnw43 {
+    background: blue;
   }
 }
 
 @media (min-width:11200px) {
-  .css-nhhz1q {
-    color: darkorchid;
-  }
-}"
-`;
-
-exports[`facepaint undefined 1`] = `"css-196uzh"`;
-
-exports[`facepaint undefined 2`] = `
-.glamor-0 {
-  color: red;
-}
-
-@media (min-width:920px) {
-  .glamor-0 {
-    color: blue;
-  }
-}
-
-@media (min-width:1120px) {
-  .glamor-0 {
-    color: darkorchid;
-  }
-}
-
-<div
-  className="glamor-0"
->
-  Basic
-</div>
-`;
-
-exports[`facepaint undefined 3`] = `
-".css-196uzh {
-  color: red;
-}
-
-@media (min-width:920px) {
-  .css-196uzh {
-    color: blue;
-  }
-}
-
-@media (min-width:1120px) {
-  .css-196uzh {
-    color: darkorchid;
+  .css-1ahnw43 {
+    background: orange;
   }
 }"
 `;

--- a/test/__snapshots__/index.test.js.snap
+++ b/test/__snapshots__/index.test.js.snap
@@ -1,5 +1,193 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`facepaint array values with selectors 1`] = `"css-1ot4erq"`;
+
+exports[`facepaint array values with selectors 2`] = `
+.glamor-0 .current-index {
+  color: blue;
+  margin-right: 15px;
+  display: none;
+  -webkit-letter-spacing: 3px;
+  -moz-letter-spacing: 3px;
+  -ms-letter-spacing: 3px;
+  letter-spacing: 3px;
+}
+
+@media (min-width:420px) {
+  .glamor-0 .current-index {
+    color: red;
+  }
+}
+
+@media (min-width:420px) {
+  .glamor-0 .current-index {
+    display: block;
+  }
+}
+
+<div
+  className="glamor-0"
+>
+  <div
+    className="foo"
+  >
+    foo
+  </div>
+  function
+</div>
+`;
+
+exports[`facepaint array values with selectors 3`] = `
+".css-1ot4erq .current-index {
+  color: blue;
+  margin-right: 15px;
+  display: none;
+  -webkit-letter-spacing: 3px;
+  -moz-letter-spacing: 3px;
+  -ms-letter-spacing: 3px;
+  letter-spacing: 3px;
+}
+
+@media (min-width:420px) {
+  .css-1ot4erq .current-index {
+    color: red;
+  }
+}
+
+@media (min-width:420px) {
+  .css-1ot4erq .current-index {
+    display: block;
+  }
+}"
+`;
+
+exports[`facepaint basic 1`] = `"css-xee1ha"`;
+
+exports[`facepaint basic 2`] = `
+.glamor-0 {
+  color: red;
+}
+
+@media (min-width:420px) {
+  .glamor-0 {
+    color: green;
+  }
+}
+
+@media (min-width:920px) {
+  .glamor-0 {
+    color: blue;
+  }
+}
+
+@media (min-width:1120px) {
+  .glamor-0 {
+    color: darkorchid;
+  }
+}
+
+<div
+  className="glamor-0"
+>
+  Basic
+</div>
+`;
+
+exports[`facepaint basic 3`] = `
+".css-xee1ha {
+  color: red;
+}
+
+@media (min-width:420px) {
+  .css-xee1ha {
+    color: green;
+  }
+}
+
+@media (min-width:920px) {
+  .css-xee1ha {
+    color: blue;
+  }
+}
+
+@media (min-width:1120px) {
+  .css-xee1ha {
+    color: darkorchid;
+  }
+}"
+`;
+
+exports[`facepaint boolean, null, and undefined values 1`] = `"css-dhb7kq"`;
+
+exports[`facepaint boolean, null, and undefined values 2`] = `
+.glamor-0 {
+  color: blue;
+  color: red;
+}
+
+<div
+  className="glamor-0"
+>
+  <div
+    className="foo"
+  >
+    foo
+  </div>
+  function
+</div>
+`;
+
+exports[`facepaint boolean, null, and undefined values 3`] = `
+".css-dhb7kq {
+  color: blue;
+  color: red;
+}"
+`;
+
+exports[`facepaint holes 1`] = `"css-196uzh"`;
+
+exports[`facepaint holes 2`] = `
+.glamor-0 {
+  color: red;
+}
+
+@media (min-width:920px) {
+  .glamor-0 {
+    color: blue;
+  }
+}
+
+@media (min-width:1120px) {
+  .glamor-0 {
+    color: darkorchid;
+  }
+}
+
+<div
+  className="glamor-0"
+>
+  Basic
+</div>
+`;
+
+exports[`facepaint holes 3`] = `
+".css-196uzh {
+  color: red;
+}
+
+@media (min-width:920px) {
+  .css-196uzh {
+    color: blue;
+  }
+}
+
+@media (min-width:1120px) {
+  .css-196uzh {
+    color: darkorchid;
+  }
+}"
+`;
+
 exports[`facepaint literal 1 1`] = `"css-1n438h9"`;
 
 exports[`facepaint literal 1 2`] = `
@@ -116,6 +304,488 @@ exports[`facepaint literal all 3`] = `
 @media (min-width:11200px) {
   .css-1ahnw43 {
     background: orange;
+  }
+}"
+`;
+
+exports[`facepaint multiple 1`] = `"css-egce6e"`;
+
+exports[`facepaint multiple 2`] = `
+.glamor-0 {
+  color: red;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  font-size: 12px;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+@media (min-width:420px) {
+  .glamor-0 {
+    color: green;
+    display: block;
+  }
+}
+
+@media (min-width:920px) {
+  .glamor-0 {
+    color: blue;
+    display: inline-block;
+  }
+}
+
+@media (min-width:1120px) {
+  .glamor-0 {
+    color: darkorchid;
+    display: table;
+  }
+}
+
+<div
+  className="glamor-0"
+>
+  multiple
+</div>
+`;
+
+exports[`facepaint multiple 3`] = `
+".css-egce6e {
+  color: red;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  font-size: 12px;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+@media (min-width:420px) {
+  .css-egce6e {
+    color: green;
+    display: block;
+  }
+}
+
+@media (min-width:920px) {
+  .css-egce6e {
+    color: blue;
+    display: inline-block;
+  }
+}
+
+@media (min-width:1120px) {
+  .css-egce6e {
+    color: darkorchid;
+    display: table;
+  }
+}"
+`;
+
+exports[`facepaint nested 1`] = `"css-rbuh8g"`;
+
+exports[`facepaint nested 2`] = `
+.glamor-0 {
+  background-color: hotpink;
+  text-align: center;
+  width: 25%;
+}
+
+.glamor-0 .foo {
+  color: red;
+}
+
+.glamor-0 .foo img {
+  height: 10px;
+}
+
+@media (min-width:420px) {
+  .glamor-0 {
+    width: 50%;
+  }
+}
+
+@media (min-width:920px) {
+  .glamor-0 {
+    width: 75%;
+  }
+}
+
+@media (min-width:1120px) {
+  .glamor-0 {
+    width: 100%;
+  }
+}
+
+@media (min-width:420px) {
+  .glamor-0 .foo {
+    color: green;
+  }
+}
+
+@media (min-width:920px) {
+  .glamor-0 .foo {
+    color: blue;
+  }
+}
+
+@media (min-width:1120px) {
+  .glamor-0 .foo {
+    color: darkorchid;
+  }
+}
+
+@media (min-width:420px) {
+  .glamor-0 .foo img {
+    height: 15px;
+  }
+}
+
+@media (min-width:920px) {
+  .glamor-0 .foo img {
+    height: 20px;
+  }
+}
+
+@media (min-width:1120px) {
+  .glamor-0 .foo img {
+    height: 25px;
+  }
+}
+
+<div
+  className="glamor-0"
+>
+  <div
+    className="foo"
+  >
+    foo
+  </div>
+  function
+</div>
+`;
+
+exports[`facepaint nested 3`] = `
+".css-rbuh8g {
+  background-color: hotpink;
+  text-align: center;
+  width: 25%;
+}
+
+@media (min-width:420px) {
+  .css-rbuh8g {
+    width: 50%;
+  }
+}
+
+@media (min-width:920px) {
+  .css-rbuh8g {
+    width: 75%;
+  }
+}
+
+@media (min-width:1120px) {
+  .css-rbuh8g {
+    width: 100%;
+  }
+}
+
+.css-rbuh8g .foo {
+  color: red;
+}
+
+@media (min-width:420px) {
+  .css-rbuh8g .foo {
+    color: green;
+  }
+}
+
+@media (min-width:920px) {
+  .css-rbuh8g .foo {
+    color: blue;
+  }
+}
+
+@media (min-width:1120px) {
+  .css-rbuh8g .foo {
+    color: darkorchid;
+  }
+}
+
+.css-rbuh8g .foo img {
+  height: 10px;
+}
+
+@media (min-width:420px) {
+  .css-rbuh8g .foo img {
+    height: 15px;
+  }
+}
+
+@media (min-width:920px) {
+  .css-rbuh8g .foo img {
+    height: 20px;
+  }
+}
+
+@media (min-width:1120px) {
+  .css-rbuh8g .foo img {
+    height: 25px;
+  }
+}"
+`;
+
+exports[`facepaint nested arrays 1`] = `"css-1faqh3h"`;
+
+exports[`facepaint nested arrays 2`] = `
+.glamor-0 {
+  color: red;
+}
+
+@media (min-width:420px) {
+  .glamor-0 {
+    color: blue;
+  }
+}
+
+@media (min-width:920px) {
+  .glamor-0 {
+    color: darkorchid;
+  }
+}
+
+<div
+  className="glamor-0"
+>
+  Basic
+</div>
+`;
+
+exports[`facepaint nested arrays 3`] = `
+".css-1faqh3h {
+  color: red;
+}
+
+@media (min-width:420px) {
+  .css-1faqh3h {
+    color: blue;
+  }
+}
+
+@media (min-width:920px) {
+  .css-1faqh3h {
+    color: darkorchid;
+  }
+}"
+`;
+
+exports[`facepaint pseudo 1`] = `"css-1guvnfu"`;
+
+exports[`facepaint pseudo 2`] = `
+.glamor-0 {
+  background-color: hotpink;
+  text-align: center;
+  width: 25%;
+}
+
+.glamor-0:hover {
+  width: 50%;
+}
+
+.glamor-0:active {
+  width: 75%;
+}
+
+.glamor-0:focus {
+  width: 100%;
+}
+
+.glamor-0 .foo {
+  color: red;
+}
+
+.glamor-0 .foo:hover {
+  color: green;
+}
+
+.glamor-0 .foo:active {
+  color: blue;
+}
+
+.glamor-0 .foo:focus {
+  color: darkorchid;
+}
+
+.glamor-0 .foo img {
+  height: 10px;
+}
+
+.glamor-0 .foo img:hover {
+  height: 15px;
+}
+
+.glamor-0 .foo img:active {
+  height: 20px;
+}
+
+.glamor-0 .foo img:focus {
+  height: 25px;
+}
+
+<div
+  className="glamor-0"
+>
+  <div
+    className="foo"
+  >
+    foo
+  </div>
+  function
+</div>
+`;
+
+exports[`facepaint pseudo 3`] = `
+".css-1guvnfu {
+  background-color: hotpink;
+  text-align: center;
+  width: 25%;
+}
+
+.css-1guvnfu:hover {
+  width: 50%;
+}
+
+.css-1guvnfu:active {
+  width: 75%;
+}
+
+.css-1guvnfu:focus {
+  width: 100%;
+}
+
+.css-1guvnfu .foo {
+  color: red;
+}
+
+.css-1guvnfu .foo:hover {
+  color: green;
+}
+
+.css-1guvnfu .foo:active {
+  color: blue;
+}
+
+.css-1guvnfu .foo:focus {
+  color: darkorchid;
+}
+
+.css-1guvnfu .foo img {
+  height: 10px;
+}
+
+.css-1guvnfu .foo img:hover {
+  height: 15px;
+}
+
+.css-1guvnfu .foo img:active {
+  height: 20px;
+}
+
+.css-1guvnfu .foo img:focus {
+  height: 25px;
+}"
+`;
+
+exports[`facepaint repeating 1`] = `"css-nhhz1q"`;
+
+exports[`facepaint repeating 2`] = `
+.glamor-0 {
+  color: red;
+}
+
+@media (min-width:420px) {
+  .glamor-0 {
+    color: blue;
+  }
+}
+
+@media (min-width:11200px) {
+  .glamor-0 {
+    color: darkorchid;
+  }
+}
+
+<div
+  className="glamor-0"
+>
+  Basic
+</div>
+`;
+
+exports[`facepaint repeating 3`] = `
+".css-nhhz1q {
+  color: red;
+}
+
+@media (min-width:420px) {
+  .css-nhhz1q {
+    color: blue;
+  }
+}
+
+@media (min-width:11200px) {
+  .css-nhhz1q {
+    color: darkorchid;
+  }
+}"
+`;
+
+exports[`facepaint undefined 1`] = `"css-196uzh"`;
+
+exports[`facepaint undefined 2`] = `
+.glamor-0 {
+  color: red;
+}
+
+@media (min-width:920px) {
+  .glamor-0 {
+    color: blue;
+  }
+}
+
+@media (min-width:1120px) {
+  .glamor-0 {
+    color: darkorchid;
+  }
+}
+
+<div
+  className="glamor-0"
+>
+  Basic
+</div>
+`;
+
+exports[`facepaint undefined 3`] = `
+".css-196uzh {
+  color: red;
+}
+
+@media (min-width:920px) {
+  .css-196uzh {
+    color: blue;
+  }
+}
+
+@media (min-width:1120px) {
+  .css-196uzh {
+    color: darkorchid;
   }
 }"
 `;

--- a/test/__snapshots__/index.test.js.snap
+++ b/test/__snapshots__/index.test.js.snap
@@ -308,6 +308,90 @@ exports[`facepaint literal all 3`] = `
 }"
 `;
 
+exports[`facepaint literal: prevent unexpected selector 1`] = `"css-15ynynd"`;
+
+exports[`facepaint literal: prevent unexpected selector 2`] = `
+@media (min-width:420px) {
+  .glamor-0 {
+    margin-top: 1px;
+  }
+}
+
+@media (min-width:920px) {
+  .glamor-0 {
+    margin-top: 2px;
+  }
+}
+
+@media (min-width:420px) {
+  .glamor-0 {
+    margin-top: 500px;
+  }
+}
+
+@media (min-width:920px) {
+  .glamor-0 {
+    margin-top: 500px;
+  }
+}
+
+<div
+  className="glamor-0"
+>
+  foo
+</div>
+`;
+
+exports[`facepaint literal: prevent unexpected selector 3`] = `
+"@media (min-width:420px) {
+  .css-1ca8ec {
+    margin-top: 1px;
+  }
+}
+
+@media (min-width:920px) {
+  .css-1ca8ec {
+    margin-top: 2px;
+  }
+}
+
+@media (min-width:420px) {
+  .css-13rmv1r {
+    margin-top: 500px;
+  }
+}
+
+@media (min-width:920px) {
+  .css-13rmv1r {
+    margin-top: 500px;
+  }
+}
+
+@media (min-width:420px) {
+  .css-15ynynd {
+    margin-top: 1px;
+  }
+}
+
+@media (min-width:920px) {
+  .css-15ynynd {
+    margin-top: 2px;
+  }
+}
+
+@media (min-width:420px) {
+  .css-15ynynd {
+    margin-top: 500px;
+  }
+}
+
+@media (min-width:920px) {
+  .css-15ynynd {
+    margin-top: 500px;
+  }
+}"
+`;
+
 exports[`facepaint multiple 1`] = `"css-egce6e"`;
 
 exports[`facepaint multiple 2`] = `

--- a/test/__snapshots__/index.test.js.snap
+++ b/test/__snapshots__/index.test.js.snap
@@ -2,19 +2,13 @@
 
 exports[`facepaint array values with selectors 1`] = `
 .glamor-0 .current-index {
+  color: blue;
   margin-right: 15px;
+  display: none;
   -webkit-letter-spacing: 3px;
   -moz-letter-spacing: 3px;
   -ms-letter-spacing: 3px;
   letter-spacing: 3px;
-}
-
-.glamor-0 .current-index {
-  color: blue;
-}
-
-.glamor-0 .current-index {
-  display: none;
 }
 
 @media (min-width:420px) {
@@ -42,30 +36,24 @@ exports[`facepaint array values with selectors 1`] = `
 `;
 
 exports[`facepaint array values with selectors 2`] = `
-".css-1n491te .current-index {
+".css-1ot4erq .current-index {
+  color: blue;
   margin-right: 15px;
+  display: none;
   -webkit-letter-spacing: 3px;
   -moz-letter-spacing: 3px;
   -ms-letter-spacing: 3px;
   letter-spacing: 3px;
 }
 
-.css-1n491te .current-index {
-  color: blue;
-}
-
 @media (min-width:420px) {
-  .css-1n491te .current-index {
+  .css-1ot4erq .current-index {
     color: red;
   }
 }
 
-.css-1n491te .current-index {
-  display: none;
-}
-
 @media (min-width:420px) {
-  .css-1n491te .current-index {
+  .css-1ot4erq .current-index {
     display: block;
   }
 }"
@@ -102,24 +90,24 @@ exports[`facepaint basic 1`] = `
 `;
 
 exports[`facepaint basic 2`] = `
-".css-17umrpw {
+".css-xee1ha {
   color: red;
 }
 
 @media (min-width:420px) {
-  .css-17umrpw {
+  .css-xee1ha {
     color: green;
   }
 }
 
 @media (min-width:920px) {
-  .css-17umrpw {
+  .css-xee1ha {
     color: blue;
   }
 }
 
 @media (min-width:1120px) {
-  .css-17umrpw {
+  .css-xee1ha {
     color: darkorchid;
   }
 }"
@@ -152,18 +140,9 @@ exports[`facepaint boolean, null, and undefined values 2`] = `
 
 exports[`facepaint composition 1`] = `
 .glamor-0 {
-  background: orange;
-}
-
-.glamor-0 {
   background: green;
-}
-
-.glamor-0 {
   background: orange;
-}
-
-.glamor-0 {
+  background: orange;
   background: orange;
 }
 
@@ -179,12 +158,12 @@ exports[`facepaint composition 1`] = `
 `;
 
 exports[`facepaint composition 2`] = `
-".css-1nun30 {
+".css-16gx40p {
   background: green;
 }
 
 @media (min-width:420px) {
-  .css-1nun30 {
+  .css-16gx40p {
     background: blue;
   }
 }
@@ -193,30 +172,17 @@ exports[`facepaint composition 2`] = `
   background: orange;
 }
 
-.css-128fsyx {
-  background: orange;
-}
-
-.css-1ox2i6c {
-  background: orange;
-}
-
-.css-1ox2i6c {
+.css-1plng0y {
   background: green;
+  background: orange;
+  background: orange;
+  background: orange;
 }
 
 @media (min-width:420px) {
-  .css-1ox2i6c {
+  .css-1plng0y {
     background: blue;
   }
-}
-
-.css-1ox2i6c {
-  background: orange;
-}
-
-.css-1ox2i6c {
-  background: orange;
 }"
 `;
 
@@ -245,19 +211,223 @@ exports[`facepaint holes 1`] = `
 `;
 
 exports[`facepaint holes 2`] = `
-".css-1myvor3 {
+".css-196uzh {
   color: red;
 }
 
 @media (min-width:920px) {
-  .css-1myvor3 {
+  .css-196uzh {
     color: blue;
   }
 }
 
 @media (min-width:1120px) {
-  .css-1myvor3 {
+  .css-196uzh {
     color: darkorchid;
+  }
+}"
+`;
+
+exports[`facepaint literal 1 1`] = `"css-1n438h9"`;
+
+exports[`facepaint literal 1 2`] = `
+@media (min-width:420px) {
+  .glamor-0 {
+    background: red;
+  }
+}
+
+<div
+  className="glamor-0"
+>
+  foo
+</div>
+`;
+
+exports[`facepaint literal 1 3`] = `
+"@media (min-width:420px) {
+  .css-1n438h9 {
+    background: red;
+  }
+}"
+`;
+
+exports[`facepaint literal 2 1`] = `"css-1k7f7mv"`;
+
+exports[`facepaint literal 2 2`] = `
+@media (min-width:420px) {
+  .glamor-0 {
+    background: red;
+  }
+}
+
+@media (min-width:920px) {
+  .glamor-0 {
+    background: green;
+  }
+}
+
+<div
+  className="glamor-0"
+>
+  foo
+</div>
+`;
+
+exports[`facepaint literal 2 3`] = `
+"@media (min-width:420px) {
+  .css-1k7f7mv {
+    background: red;
+  }
+}
+
+@media (min-width:920px) {
+  .css-1k7f7mv {
+    background: green;
+  }
+}"
+`;
+
+exports[`facepaint literal all 1`] = `"css-1ahnw43"`;
+
+exports[`facepaint literal all 2`] = `
+@media (min-width:420px) {
+  .glamor-0 {
+    background: red;
+  }
+}
+
+@media (min-width:920px) {
+  .glamor-0 {
+    background: green;
+  }
+}
+
+@media (min-width:1120px) {
+  .glamor-0 {
+    background: blue;
+  }
+}
+
+@media (min-width:11200px) {
+  .glamor-0 {
+    background: orange;
+  }
+}
+
+<div
+  className="glamor-0"
+>
+  foo
+</div>
+`;
+
+exports[`facepaint literal all 3`] = `
+"@media (min-width:420px) {
+  .css-1ahnw43 {
+    background: red;
+  }
+}
+
+@media (min-width:920px) {
+  .css-1ahnw43 {
+    background: green;
+  }
+}
+
+@media (min-width:1120px) {
+  .css-1ahnw43 {
+    background: blue;
+  }
+}
+
+@media (min-width:11200px) {
+  .css-1ahnw43 {
+    background: orange;
+  }
+}"
+`;
+
+exports[`facepaint literal: prevent unexpected selector 1`] = `"css-15ynynd"`;
+
+exports[`facepaint literal: prevent unexpected selector 2`] = `
+@media (min-width:420px) {
+  .glamor-0 {
+    margin-top: 1px;
+  }
+}
+
+@media (min-width:920px) {
+  .glamor-0 {
+    margin-top: 2px;
+  }
+}
+
+@media (min-width:420px) {
+  .glamor-0 {
+    margin-top: 500px;
+  }
+}
+
+@media (min-width:920px) {
+  .glamor-0 {
+    margin-top: 500px;
+  }
+}
+
+<div
+  className="glamor-0"
+>
+  foo
+</div>
+`;
+
+exports[`facepaint literal: prevent unexpected selector 3`] = `
+"@media (min-width:420px) {
+  .css-1ca8ec {
+    margin-top: 1px;
+  }
+}
+
+@media (min-width:920px) {
+  .css-1ca8ec {
+    margin-top: 2px;
+  }
+}
+
+@media (min-width:420px) {
+  .css-13rmv1r {
+    margin-top: 500px;
+  }
+}
+
+@media (min-width:920px) {
+  .css-13rmv1r {
+    margin-top: 500px;
+  }
+}
+
+@media (min-width:420px) {
+  .css-15ynynd {
+    margin-top: 1px;
+  }
+}
+
+@media (min-width:920px) {
+  .css-15ynynd {
+    margin-top: 2px;
+  }
+}
+
+@media (min-width:420px) {
+  .css-15ynynd {
+    margin-top: 500px;
+  }
+}
+
+@media (min-width:920px) {
+  .css-15ynynd {
+    margin-top: 500px;
   }
 }"
 `;
@@ -265,9 +435,6 @@ exports[`facepaint holes 2`] = `
 exports[`facepaint more composition 1`] = `
 .glamor-0 {
   margin-top: 1px;
-}
-
-.glamor-0 {
   margin-top: 500px;
 }
 
@@ -283,50 +450,44 @@ exports[`facepaint more composition 1`] = `
 `;
 
 exports[`facepaint more composition 2`] = `
-".css-1yp7eyp {
+".css-1lg6icu {
   margin-top: 1px;
 }
 
 @media (min-width:420px) {
-  .css-1yp7eyp {
+  .css-1lg6icu {
     margin-top: 2px;
   }
 }
 
-.css-zpi702 {
+.css-lk2z8m {
   margin-top: 500px;
 }
 
-.css-1ydslhg {
+.css-1874a9x {
   margin-top: 1px;
+  margin-top: 500px;
 }
 
 @media (min-width:420px) {
-  .css-1ydslhg {
+  .css-1874a9x {
     margin-top: 2px;
   }
-}
-
-.css-1ydslhg {
-  margin-top: 500px;
 }"
 `;
 
 exports[`facepaint multiple 1`] = `
-.glamor-0 {
-  font-size: 12px;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
 .glamor-0 {
   color: red;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  font-size: 12px;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
 }
 
 @media (min-width:420px) {
@@ -358,7 +519,12 @@ exports[`facepaint multiple 1`] = `
 `;
 
 exports[`facepaint multiple 2`] = `
-".css-dfpbx9 {
+".css-egce6e {
+  color: red;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
   font-size: 12px;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -366,30 +532,22 @@ exports[`facepaint multiple 2`] = `
   align-items: center;
 }
 
-.css-dfpbx9 {
-  color: red;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-}
-
 @media (min-width:420px) {
-  .css-dfpbx9 {
+  .css-egce6e {
     color: green;
     display: block;
   }
 }
 
 @media (min-width:920px) {
-  .css-dfpbx9 {
+  .css-egce6e {
     color: blue;
     display: inline-block;
   }
 }
 
 @media (min-width:1120px) {
-  .css-dfpbx9 {
+  .css-egce6e {
     color: darkorchid;
     display: table;
   }
@@ -400,9 +558,6 @@ exports[`facepaint nested 1`] = `
 .glamor-0 {
   background-color: hotpink;
   text-align: center;
-}
-
-.glamor-0 {
   width: 25%;
 }
 
@@ -481,73 +636,70 @@ exports[`facepaint nested 1`] = `
 `;
 
 exports[`facepaint nested 2`] = `
-".css-1xa5b6k {
+".css-rbuh8g {
   background-color: hotpink;
   text-align: center;
-}
-
-.css-1xa5b6k {
   width: 25%;
 }
 
 @media (min-width:420px) {
-  .css-1xa5b6k {
+  .css-rbuh8g {
     width: 50%;
   }
 }
 
 @media (min-width:920px) {
-  .css-1xa5b6k {
+  .css-rbuh8g {
     width: 75%;
   }
 }
 
 @media (min-width:1120px) {
-  .css-1xa5b6k {
+  .css-rbuh8g {
     width: 100%;
   }
 }
 
-.css-1xa5b6k .foo {
+.css-rbuh8g .foo {
   color: red;
 }
 
 @media (min-width:420px) {
-  .css-1xa5b6k .foo {
+  .css-rbuh8g .foo {
     color: green;
   }
 }
 
 @media (min-width:920px) {
-  .css-1xa5b6k .foo {
+  .css-rbuh8g .foo {
     color: blue;
   }
 }
 
 @media (min-width:1120px) {
-  .css-1xa5b6k .foo {
+  .css-rbuh8g .foo {
     color: darkorchid;
   }
 }
 
-.css-1xa5b6k .foo img {
+.css-rbuh8g .foo img {
   height: 10px;
 }
 
 @media (min-width:420px) {
-  .css-1xa5b6k .foo img {
+  .css-rbuh8g .foo img {
     height: 15px;
   }
 }
 
 @media (min-width:920px) {
-  .css-1xa5b6k .foo img {
+  .css-rbuh8g .foo img {
     height: 20px;
   }
 }
 
 @media (min-width:1120px) {
-  .css-1xa5b6k .foo img {
+  .css-rbuh8g .foo img {
     height: 25px;
   }
 }"
@@ -578,18 +730,18 @@ exports[`facepaint nested arrays 1`] = `
 `;
 
 exports[`facepaint nested arrays 2`] = `
-".css-1kdodwg {
+".css-1faqh3h {
   color: red;
 }
 
 @media (min-width:420px) {
-  .css-1kdodwg {
+  .css-1faqh3h {
     color: blue;
   }
 }
 
 @media (min-width:920px) {
-  .css-1kdodwg {
+  .css-1faqh3h {
     color: darkorchid;
   }
 }"
@@ -599,9 +751,6 @@ exports[`facepaint pseudo 1`] = `
 .glamor-0 {
   background-color: hotpink;
   text-align: center;
-}
-
-.glamor-0 {
   width: 25%;
 }
 
@@ -662,56 +811,53 @@ exports[`facepaint pseudo 1`] = `
 `;
 
 exports[`facepaint pseudo 2`] = `
-".css-13tn68s {
+".css-1guvnfu {
   background-color: hotpink;
   text-align: center;
-}
-
-.css-13tn68s {
   width: 25%;
 }
 
-.css-13tn68s:hover {
+.css-1guvnfu:hover {
   width: 50%;
 }
 
-.css-13tn68s:active {
+.css-1guvnfu:active {
   width: 75%;
 }
 
-.css-13tn68s:focus {
+.css-1guvnfu:focus {
   width: 100%;
 }
 
-.css-13tn68s .foo {
+.css-1guvnfu .foo {
   color: red;
 }
 
-.css-13tn68s .foo:hover {
+.css-1guvnfu .foo:hover {
   color: green;
 }
 
-.css-13tn68s .foo:active {
+.css-1guvnfu .foo:active {
   color: blue;
 }
 
-.css-13tn68s .foo:focus {
+.css-1guvnfu .foo:focus {
   color: darkorchid;
 }
 
-.css-13tn68s .foo img {
+.css-1guvnfu .foo img {
   height: 10px;
 }
 
-.css-13tn68s .foo img:hover {
+.css-1guvnfu .foo img:hover {
   height: 15px;
 }
 
-.css-13tn68s .foo img:active {
+.css-1guvnfu .foo img:active {
   height: 20px;
 }
 
-.css-13tn68s .foo img:focus {
+.css-1guvnfu .foo img:focus {
   height: 25px;
 }"
 `;
@@ -741,18 +887,18 @@ exports[`facepaint repeating 1`] = `
 `;
 
 exports[`facepaint repeating 2`] = `
-".css-1ki7d2p {
+".css-nhhz1q {
   color: red;
 }
 
 @media (min-width:420px) {
-  .css-1ki7d2p {
+  .css-nhhz1q {
     color: blue;
   }
 }
 
 @media (min-width:11200px) {
-  .css-1ki7d2p {
+  .css-nhhz1q {
     color: darkorchid;
   }
 }"
@@ -783,18 +929,18 @@ exports[`facepaint undefined 1`] = `
 `;
 
 exports[`facepaint undefined 2`] = `
-".css-1myvor3 {
+".css-196uzh {
   color: red;
 }
 
 @media (min-width:920px) {
-  .css-1myvor3 {
+  .css-196uzh {
     color: blue;
   }
 }
 
 @media (min-width:1120px) {
-  .css-1myvor3 {
+  .css-196uzh {
     color: darkorchid;
   }
 }"

--- a/test/__snapshots__/styled-components.test.js.snap
+++ b/test/__snapshots__/styled-components.test.js.snap
@@ -56,19 +56,16 @@ exports[`facepaint holes 1`] = `
 
 exports[`facepaint multiple 1`] = `
 .c0 {
-  font-size: 12px;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-.c0 {
   color: red;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  font-size: 12px;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
 }
 
 @media (min-width:420px) {
@@ -103,9 +100,6 @@ exports[`facepaint nested 1`] = `
 .c0 {
   background-color: hotpink;
   text-align: center;
-}
-
-.c0 {
   width: 25%;
 }
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-sparse-arrays */
 import React from 'react'
 import renderer from 'react-test-renderer'
-import { css, sheet, flush } from 'emotion'
+import { css, cx, sheet, flush } from 'emotion'
 
 import facepaint from '../src/index'
 
@@ -220,6 +220,17 @@ describe('facepaint', () => {
 
   test('literal all', () => {
     const result = css(mql({ background: ['red', 'green', 'blue', 'orange'] }))
+    expect(result).toMatchSnapshot()
+    const tree = renderer.create(<div css={result}>foo</div>).toJSON()
+
+    expect(tree).toMatchSnapshot()
+    expect(sheet).toMatchSnapshot()
+  })
+
+  test('literal: prevent unexpected selector', () => {
+    const styles1 = css(mql({ marginTop: [1, 2] }))
+    const styles2 = css(mql({ marginTop: [500, 500] }))
+    const result = cx(styles1, styles2)
     expect(result).toMatchSnapshot()
     const tree = renderer.create(<div css={result}>foo</div>).toJSON()
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -200,7 +200,7 @@ describe('facepaint', () => {
     expect(sheet).toMatchSnapshot()
   })
 
-  test.only('literal 1', () => {
+  test('literal 1', () => {
     const result = css(mql({ background: ['red'] }))
     expect(result).toMatchSnapshot()
     const tree = renderer.create(<div css={result}>foo</div>).toJSON()
@@ -209,7 +209,7 @@ describe('facepaint', () => {
     expect(sheet).toMatchSnapshot()
   })
 
-  test.only('literal 2', () => {
+  test('literal 2', () => {
     const result = css(mql({ background: ['red', 'green'] }))
     expect(result).toMatchSnapshot()
     const tree = renderer.create(<div css={result}>foo</div>).toJSON()
@@ -218,7 +218,7 @@ describe('facepaint', () => {
     expect(sheet).toMatchSnapshot()
   })
 
-  test.only('literal all', () => {
+  test('literal all', () => {
     const result = css(mql({ background: ['red', 'green', 'blue', 'orange'] }))
     expect(result).toMatchSnapshot()
     const tree = renderer.create(<div css={result}>foo</div>).toJSON()

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -15,6 +15,16 @@ const mq = facepaint(
   { overlap: true }
 )
 
+const mql = facepaint(
+  [
+    '@media(min-width: 420px)',
+    '@media(min-width: 920px)',
+    '@media(min-width: 1120px)',
+    '@media(min-width: 11200px)'
+  ],
+  { literal: true }
+)
+
 const pseudo = facepaint([':hover', ':active', ':focus'])
 
 describe('facepaint', () => {
@@ -186,6 +196,33 @@ describe('facepaint', () => {
         </div>
       )
       .toJSON()
+    expect(tree).toMatchSnapshot()
+    expect(sheet).toMatchSnapshot()
+  })
+
+  test.only('literal 1', () => {
+    const result = css(mql({ background: ['red'] }))
+    expect(result).toMatchSnapshot()
+    const tree = renderer.create(<div css={result}>foo</div>).toJSON()
+
+    expect(tree).toMatchSnapshot()
+    expect(sheet).toMatchSnapshot()
+  })
+
+  test.only('literal 2', () => {
+    const result = css(mql({ background: ['red', 'green'] }))
+    expect(result).toMatchSnapshot()
+    const tree = renderer.create(<div css={result}>foo</div>).toJSON()
+
+    expect(tree).toMatchSnapshot()
+    expect(sheet).toMatchSnapshot()
+  })
+
+  test.only('literal all', () => {
+    const result = css(mql({ background: ['red', 'green', 'blue', 'orange'] }))
+    expect(result).toMatchSnapshot()
+    const tree = renderer.create(<div css={result}>foo</div>).toJSON()
+
     expect(tree).toMatchSnapshot()
     expect(sheet).toMatchSnapshot()
   })


### PR DESCRIPTION
Adds literal mode, which omits the initial "base" CSS style that is assumed in the default mode.

For `mq({ background: ['red', 'green'] })`, this will take the output from

```css
.css-foo {
  background: red;
}

@mediaquery1 {
 .css-foo {
    background: green;
  }
}
```

to

```css
@mediaquery1 {
  .css-foo {
    background: red;
  }
}

@mediaquery2 { 
  .css-foo  {
    background: green;
  }
}
```

- Closes #3 - https://codesandbox.io/s/r5xn7j1n2o
- Closes #4
- Closes #6 - https://codesandbox.io/s/y480v8109 

---

*^ revised PR description credit to @kpdecker*