### PR TITLE
Always use ampersand

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-param-reassign */
 export default function(breakpoints, { overlap } = {}) {
-  const mq = [''].concat(breakpoints)
+  const mq = ['&'].concat(breakpoints)
   function flatten(obj) {
     if (typeof obj !== 'object' || obj == null) {
       return []
@@ -30,9 +30,7 @@ export default function(breakpoints, { overlap } = {}) {
 
           prior = v
 
-          if (index === 0) {
-            slots[key] = v
-          } else if (!slots[mq[index]]) {
+          if (slots[mq[index]] === undefined) {
             slots[mq[index]] = { [key]: v }
           } else {
             slots[mq[index]][key] = v

--- a/test/__snapshots__/index.test.js.snap
+++ b/test/__snapshots__/index.test.js.snap
@@ -2,13 +2,19 @@
 
 exports[`facepaint array values with selectors 1`] = `
 .glamor-0 .current-index {
-  color: blue;
   margin-right: 15px;
-  display: none;
   -webkit-letter-spacing: 3px;
   -moz-letter-spacing: 3px;
   -ms-letter-spacing: 3px;
   letter-spacing: 3px;
+}
+
+.glamor-0 .current-index {
+  color: blue;
+}
+
+.glamor-0 .current-index {
+  display: none;
 }
 
 @media (min-width:420px) {
@@ -36,24 +42,30 @@ exports[`facepaint array values with selectors 1`] = `
 `;
 
 exports[`facepaint array values with selectors 2`] = `
-".css-1ot4erq .current-index {
-  color: blue;
+".css-1n491te .current-index {
   margin-right: 15px;
-  display: none;
   -webkit-letter-spacing: 3px;
   -moz-letter-spacing: 3px;
   -ms-letter-spacing: 3px;
   letter-spacing: 3px;
 }
 
+.css-1n491te .current-index {
+  color: blue;
+}
+
 @media (min-width:420px) {
-  .css-1ot4erq .current-index {
+  .css-1n491te .current-index {
     color: red;
   }
 }
 
+.css-1n491te .current-index {
+  display: none;
+}
+
 @media (min-width:420px) {
-  .css-1ot4erq .current-index {
+  .css-1n491te .current-index {
     display: block;
   }
 }"
@@ -90,24 +102,24 @@ exports[`facepaint basic 1`] = `
 `;
 
 exports[`facepaint basic 2`] = `
-".css-xee1ha {
+".css-17umrpw {
   color: red;
 }
 
 @media (min-width:420px) {
-  .css-xee1ha {
+  .css-17umrpw {
     color: green;
   }
 }
 
 @media (min-width:920px) {
-  .css-xee1ha {
+  .css-17umrpw {
     color: blue;
   }
 }
 
 @media (min-width:1120px) {
-  .css-xee1ha {
+  .css-17umrpw {
     color: darkorchid;
   }
 }"
@@ -163,18 +175,18 @@ exports[`facepaint holes 1`] = `
 `;
 
 exports[`facepaint holes 2`] = `
-".css-196uzh {
+".css-1myvor3 {
   color: red;
 }
 
 @media (min-width:920px) {
-  .css-196uzh {
+  .css-1myvor3 {
     color: blue;
   }
 }
 
 @media (min-width:1120px) {
-  .css-196uzh {
+  .css-1myvor3 {
     color: darkorchid;
   }
 }"
@@ -182,16 +194,19 @@ exports[`facepaint holes 2`] = `
 
 exports[`facepaint multiple 1`] = `
 .glamor-0 {
-  color: red;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
   font-size: 12px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+}
+
+.glamor-0 {
+  color: red;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
 }
 
 @media (min-width:420px) {
@@ -223,12 +238,7 @@ exports[`facepaint multiple 1`] = `
 `;
 
 exports[`facepaint multiple 2`] = `
-".css-egce6e {
-  color: red;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
+".css-dfpbx9 {
   font-size: 12px;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -236,22 +246,30 @@ exports[`facepaint multiple 2`] = `
   align-items: center;
 }
 
+.css-dfpbx9 {
+  color: red;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
 @media (min-width:420px) {
-  .css-egce6e {
+  .css-dfpbx9 {
     color: green;
     display: block;
   }
 }
 
 @media (min-width:920px) {
-  .css-egce6e {
+  .css-dfpbx9 {
     color: blue;
     display: inline-block;
   }
 }
 
 @media (min-width:1120px) {
-  .css-egce6e {
+  .css-dfpbx9 {
     color: darkorchid;
     display: table;
   }
@@ -262,6 +280,9 @@ exports[`facepaint nested 1`] = `
 .glamor-0 {
   background-color: hotpink;
   text-align: center;
+}
+
+.glamor-0 {
   width: 25%;
 }
 
@@ -340,70 +361,73 @@ exports[`facepaint nested 1`] = `
 `;
 
 exports[`facepaint nested 2`] = `
-".css-rbuh8g {
+".css-1xa5b6k {
   background-color: hotpink;
   text-align: center;
+}
+
+.css-1xa5b6k {
   width: 25%;
 }
 
 @media (min-width:420px) {
-  .css-rbuh8g {
+  .css-1xa5b6k {
     width: 50%;
   }
 }
 
 @media (min-width:920px) {
-  .css-rbuh8g {
+  .css-1xa5b6k {
     width: 75%;
   }
 }
 
 @media (min-width:1120px) {
-  .css-rbuh8g {
+  .css-1xa5b6k {
     width: 100%;
   }
 }
 
-.css-rbuh8g .foo {
+.css-1xa5b6k .foo {
   color: red;
 }
 
 @media (min-width:420px) {
-  .css-rbuh8g .foo {
+  .css-1xa5b6k .foo {
     color: green;
   }
 }
 
 @media (min-width:920px) {
-  .css-rbuh8g .foo {
+  .css-1xa5b6k .foo {
     color: blue;
   }
 }
 
 @media (min-width:1120px) {
-  .css-rbuh8g .foo {
+  .css-1xa5b6k .foo {
     color: darkorchid;
   }
 }
 
-.css-rbuh8g .foo img {
+.css-1xa5b6k .foo img {
   height: 10px;
 }
 
 @media (min-width:420px) {
-  .css-rbuh8g .foo img {
+  .css-1xa5b6k .foo img {
     height: 15px;
   }
 }
 
 @media (min-width:920px) {
-  .css-rbuh8g .foo img {
+  .css-1xa5b6k .foo img {
     height: 20px;
   }
 }
 
 @media (min-width:1120px) {
-  .css-rbuh8g .foo img {
+  .css-1xa5b6k .foo img {
     height: 25px;
   }
 }"
@@ -434,18 +458,18 @@ exports[`facepaint nested arrays 1`] = `
 `;
 
 exports[`facepaint nested arrays 2`] = `
-".css-1faqh3h {
+".css-1kdodwg {
   color: red;
 }
 
 @media (min-width:420px) {
-  .css-1faqh3h {
+  .css-1kdodwg {
     color: blue;
   }
 }
 
 @media (min-width:920px) {
-  .css-1faqh3h {
+  .css-1kdodwg {
     color: darkorchid;
   }
 }"
@@ -455,6 +479,9 @@ exports[`facepaint pseudo 1`] = `
 .glamor-0 {
   background-color: hotpink;
   text-align: center;
+}
+
+.glamor-0 {
   width: 25%;
 }
 
@@ -515,53 +542,56 @@ exports[`facepaint pseudo 1`] = `
 `;
 
 exports[`facepaint pseudo 2`] = `
-".css-1guvnfu {
+".css-13tn68s {
   background-color: hotpink;
   text-align: center;
+}
+
+.css-13tn68s {
   width: 25%;
 }
 
-.css-1guvnfu:hover {
+.css-13tn68s:hover {
   width: 50%;
 }
 
-.css-1guvnfu:active {
+.css-13tn68s:active {
   width: 75%;
 }
 
-.css-1guvnfu:focus {
+.css-13tn68s:focus {
   width: 100%;
 }
 
-.css-1guvnfu .foo {
+.css-13tn68s .foo {
   color: red;
 }
 
-.css-1guvnfu .foo:hover {
+.css-13tn68s .foo:hover {
   color: green;
 }
 
-.css-1guvnfu .foo:active {
+.css-13tn68s .foo:active {
   color: blue;
 }
 
-.css-1guvnfu .foo:focus {
+.css-13tn68s .foo:focus {
   color: darkorchid;
 }
 
-.css-1guvnfu .foo img {
+.css-13tn68s .foo img {
   height: 10px;
 }
 
-.css-1guvnfu .foo img:hover {
+.css-13tn68s .foo img:hover {
   height: 15px;
 }
 
-.css-1guvnfu .foo img:active {
+.css-13tn68s .foo img:active {
   height: 20px;
 }
 
-.css-1guvnfu .foo img:focus {
+.css-13tn68s .foo img:focus {
   height: 25px;
 }"
 `;
@@ -591,18 +621,18 @@ exports[`facepaint repeating 1`] = `
 `;
 
 exports[`facepaint repeating 2`] = `
-".css-nhhz1q {
+".css-1ki7d2p {
   color: red;
 }
 
 @media (min-width:420px) {
-  .css-nhhz1q {
+  .css-1ki7d2p {
     color: blue;
   }
 }
 
 @media (min-width:11200px) {
-  .css-nhhz1q {
+  .css-1ki7d2p {
     color: darkorchid;
   }
 }"
@@ -633,18 +663,18 @@ exports[`facepaint undefined 1`] = `
 `;
 
 exports[`facepaint undefined 2`] = `
-".css-196uzh {
+".css-1myvor3 {
   color: red;
 }
 
 @media (min-width:920px) {
-  .css-196uzh {
+  .css-1myvor3 {
     color: blue;
   }
 }
 
 @media (min-width:1120px) {
-  .css-196uzh {
+  .css-1myvor3 {
     color: darkorchid;
   }
 }"

--- a/test/__snapshots__/index.test.js.snap
+++ b/test/__snapshots__/index.test.js.snap
@@ -1,8 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`facepaint array values with selectors 1`] = `"css-1ot4erq"`;
-
-exports[`facepaint array values with selectors 2`] = `
+exports[`facepaint array values with selectors 1`] = `
 .glamor-0 .current-index {
   color: blue;
   margin-right: 15px;
@@ -37,7 +35,7 @@ exports[`facepaint array values with selectors 2`] = `
 </div>
 `;
 
-exports[`facepaint array values with selectors 3`] = `
+exports[`facepaint array values with selectors 2`] = `
 ".css-1ot4erq .current-index {
   color: blue;
   margin-right: 15px;
@@ -61,9 +59,7 @@ exports[`facepaint array values with selectors 3`] = `
 }"
 `;
 
-exports[`facepaint basic 1`] = `"css-xee1ha"`;
-
-exports[`facepaint basic 2`] = `
+exports[`facepaint basic 1`] = `
 .glamor-0 {
   color: red;
 }
@@ -93,7 +89,7 @@ exports[`facepaint basic 2`] = `
 </div>
 `;
 
-exports[`facepaint basic 3`] = `
+exports[`facepaint basic 2`] = `
 ".css-xee1ha {
   color: red;
 }
@@ -117,9 +113,7 @@ exports[`facepaint basic 3`] = `
 }"
 `;
 
-exports[`facepaint boolean, null, and undefined values 1`] = `"css-dhb7kq"`;
-
-exports[`facepaint boolean, null, and undefined values 2`] = `
+exports[`facepaint boolean, null, and undefined values 1`] = `
 .glamor-0 {
   color: blue;
   color: red;
@@ -137,16 +131,14 @@ exports[`facepaint boolean, null, and undefined values 2`] = `
 </div>
 `;
 
-exports[`facepaint boolean, null, and undefined values 3`] = `
+exports[`facepaint boolean, null, and undefined values 2`] = `
 ".css-dhb7kq {
   color: blue;
   color: red;
 }"
 `;
 
-exports[`facepaint holes 1`] = `"css-196uzh"`;
-
-exports[`facepaint holes 2`] = `
+exports[`facepaint holes 1`] = `
 .glamor-0 {
   color: red;
 }
@@ -170,7 +162,7 @@ exports[`facepaint holes 2`] = `
 </div>
 `;
 
-exports[`facepaint holes 3`] = `
+exports[`facepaint holes 2`] = `
 ".css-196uzh {
   color: red;
 }
@@ -188,9 +180,7 @@ exports[`facepaint holes 3`] = `
 }"
 `;
 
-exports[`facepaint multiple 1`] = `"css-egce6e"`;
-
-exports[`facepaint multiple 2`] = `
+exports[`facepaint multiple 1`] = `
 .glamor-0 {
   color: red;
   display: -webkit-box;
@@ -232,7 +222,7 @@ exports[`facepaint multiple 2`] = `
 </div>
 `;
 
-exports[`facepaint multiple 3`] = `
+exports[`facepaint multiple 2`] = `
 ".css-egce6e {
   color: red;
   display: -webkit-box;
@@ -268,9 +258,7 @@ exports[`facepaint multiple 3`] = `
 }"
 `;
 
-exports[`facepaint nested 1`] = `"css-rbuh8g"`;
-
-exports[`facepaint nested 2`] = `
+exports[`facepaint nested 1`] = `
 .glamor-0 {
   background-color: hotpink;
   text-align: center;
@@ -351,7 +339,7 @@ exports[`facepaint nested 2`] = `
 </div>
 `;
 
-exports[`facepaint nested 3`] = `
+exports[`facepaint nested 2`] = `
 ".css-rbuh8g {
   background-color: hotpink;
   text-align: center;
@@ -421,9 +409,7 @@ exports[`facepaint nested 3`] = `
 }"
 `;
 
-exports[`facepaint nested arrays 1`] = `"css-1faqh3h"`;
-
-exports[`facepaint nested arrays 2`] = `
+exports[`facepaint nested arrays 1`] = `
 .glamor-0 {
   color: red;
 }
@@ -447,7 +433,7 @@ exports[`facepaint nested arrays 2`] = `
 </div>
 `;
 
-exports[`facepaint nested arrays 3`] = `
+exports[`facepaint nested arrays 2`] = `
 ".css-1faqh3h {
   color: red;
 }
@@ -465,9 +451,7 @@ exports[`facepaint nested arrays 3`] = `
 }"
 `;
 
-exports[`facepaint pseudo 1`] = `"css-1guvnfu"`;
-
-exports[`facepaint pseudo 2`] = `
+exports[`facepaint pseudo 1`] = `
 .glamor-0 {
   background-color: hotpink;
   text-align: center;
@@ -530,7 +514,7 @@ exports[`facepaint pseudo 2`] = `
 </div>
 `;
 
-exports[`facepaint pseudo 3`] = `
+exports[`facepaint pseudo 2`] = `
 ".css-1guvnfu {
   background-color: hotpink;
   text-align: center;
@@ -582,9 +566,7 @@ exports[`facepaint pseudo 3`] = `
 }"
 `;
 
-exports[`facepaint repeating 1`] = `"css-nhhz1q"`;
-
-exports[`facepaint repeating 2`] = `
+exports[`facepaint repeating 1`] = `
 .glamor-0 {
   color: red;
 }
@@ -608,7 +590,7 @@ exports[`facepaint repeating 2`] = `
 </div>
 `;
 
-exports[`facepaint repeating 3`] = `
+exports[`facepaint repeating 2`] = `
 ".css-nhhz1q {
   color: red;
 }
@@ -626,9 +608,7 @@ exports[`facepaint repeating 3`] = `
 }"
 `;
 
-exports[`facepaint undefined 1`] = `"css-196uzh"`;
-
-exports[`facepaint undefined 2`] = `
+exports[`facepaint undefined 1`] = `
 .glamor-0 {
   color: red;
 }
@@ -652,7 +632,7 @@ exports[`facepaint undefined 2`] = `
 </div>
 `;
 
-exports[`facepaint undefined 3`] = `
+exports[`facepaint undefined 2`] = `
 ".css-196uzh {
   color: red;
 }

--- a/test/__snapshots__/index.test.js.snap
+++ b/test/__snapshots__/index.test.js.snap
@@ -150,6 +150,76 @@ exports[`facepaint boolean, null, and undefined values 2`] = `
 }"
 `;
 
+exports[`facepaint composition 1`] = `
+.glamor-0 {
+  background: orange;
+}
+
+.glamor-0 {
+  background: green;
+}
+
+.glamor-0 {
+  background: orange;
+}
+
+.glamor-0 {
+  background: orange;
+}
+
+@media (min-width:420px) {
+  .glamor-0 {
+    background: blue;
+  }
+}
+
+<div
+  className="glamor-0"
+/>
+`;
+
+exports[`facepaint composition 2`] = `
+".css-1nun30 {
+  background: green;
+}
+
+@media (min-width:420px) {
+  .css-1nun30 {
+    background: blue;
+  }
+}
+
+.css-1y2rzxt {
+  background: orange;
+}
+
+.css-128fsyx {
+  background: orange;
+}
+
+.css-1ox2i6c {
+  background: orange;
+}
+
+.css-1ox2i6c {
+  background: green;
+}
+
+@media (min-width:420px) {
+  .css-1ox2i6c {
+    background: blue;
+  }
+}
+
+.css-1ox2i6c {
+  background: orange;
+}
+
+.css-1ox2i6c {
+  background: orange;
+}"
+`;
+
 exports[`facepaint holes 1`] = `
 .glamor-0 {
   color: red;
@@ -189,6 +259,56 @@ exports[`facepaint holes 2`] = `
   .css-1myvor3 {
     color: darkorchid;
   }
+}"
+`;
+
+exports[`facepaint more composition 1`] = `
+.glamor-0 {
+  margin-top: 1px;
+}
+
+.glamor-0 {
+  margin-top: 500px;
+}
+
+@media (min-width:420px) {
+  .glamor-0 {
+    margin-top: 2px;
+  }
+}
+
+<div
+  className="glamor-0"
+/>
+`;
+
+exports[`facepaint more composition 2`] = `
+".css-1yp7eyp {
+  margin-top: 1px;
+}
+
+@media (min-width:420px) {
+  .css-1yp7eyp {
+    margin-top: 2px;
+  }
+}
+
+.css-zpi702 {
+  margin-top: 500px;
+}
+
+.css-1ydslhg {
+  margin-top: 1px;
+}
+
+@media (min-width:420px) {
+  .css-1ydslhg {
+    margin-top: 2px;
+  }
+}
+
+.css-1ydslhg {
+  margin-top: 500px;
 }"
 `;
 

--- a/test/__snapshots__/styled-components.test.js.snap
+++ b/test/__snapshots__/styled-components.test.js.snap
@@ -56,16 +56,19 @@ exports[`facepaint holes 1`] = `
 
 exports[`facepaint multiple 1`] = `
 .c0 {
-  color: red;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
   font-size: 12px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+}
+
+.c0 {
+  color: red;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
 }
 
 @media (min-width:420px) {
@@ -100,6 +103,9 @@ exports[`facepaint nested 1`] = `
 .c0 {
   background-color: hotpink;
   text-align: center;
+}
+
+.c0 {
   width: 25%;
 }
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-sparse-arrays */
 import React from 'react'
 import renderer from 'react-test-renderer'
-import { css, sheet, flush } from 'emotion'
+import { css, sheet, flush, cx } from 'emotion'
 
 import facepaint from '../src/index'
 
@@ -176,6 +176,23 @@ describe('facepaint', () => {
         </div>
       )
       .toJSON()
+    expect(tree).toMatchSnapshot()
+    expect(sheet).toMatchSnapshot()
+  })
+  test('composition', () => {
+    const a = css(mq({ background: ['green', 'blue'] }))
+    const b = css(mq({ background: 'orange' }))
+    const c = css(mq({ background: ['orange', 'orange'] }))
+    const d = css(mq({ background: ['orange', 'orange', 'orange', 'orange'] }))
+
+    const tree = renderer.create(<div css={cx(a, b, c, d)} />).toJSON()
+    expect(tree).toMatchSnapshot()
+    expect(sheet).toMatchSnapshot()
+  })
+  test('more composition', () => {
+    const styles1 = css(mq({ marginTop: [1, 2] }))
+    const styles2 = css(mq({ marginTop: [500, 500] }))
+    const tree = renderer.create(<div css={cx(styles1, styles2)} />).toJSON()
     expect(tree).toMatchSnapshot()
     expect(sheet).toMatchSnapshot()
   })

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -21,7 +21,6 @@ describe('facepaint', () => {
   afterEach(() => flush())
   test('basic', () => {
     const result = css(mq({ color: ['red', 'green', 'blue', 'darkorchid'] }))
-    expect(result).toMatchSnapshot()
     const tree = renderer.create(<div css={result}>Basic</div>).toJSON()
     expect(tree).toMatchSnapshot()
     expect(sheet).toMatchSnapshot()
@@ -29,7 +28,6 @@ describe('facepaint', () => {
 
   test('holes', () => {
     const result = css(mq({ color: ['red', , 'blue', 'darkorchid'] }))
-    expect(result).toMatchSnapshot()
     const tree = renderer.create(<div css={result}>Basic</div>).toJSON()
     expect(tree).toMatchSnapshot()
     expect(sheet).toMatchSnapshot()
@@ -37,7 +35,6 @@ describe('facepaint', () => {
 
   test('undefined', () => {
     const result = css(mq({ color: ['red', undefined, 'blue', 'darkorchid'] }))
-    expect(result).toMatchSnapshot()
     const tree = renderer.create(<div css={result}>Basic</div>).toJSON()
     expect(tree).toMatchSnapshot()
     expect(sheet).toMatchSnapshot()
@@ -47,7 +44,6 @@ describe('facepaint', () => {
     const result = css(
       mq({ color: ['red', 'blue', undefined, 'blue', 'darkorchid'] })
     )
-    expect(result).toMatchSnapshot()
     const tree = renderer.create(<div css={result}>Basic</div>).toJSON()
     expect(tree).toMatchSnapshot()
     expect(sheet).toMatchSnapshot()
@@ -55,7 +51,6 @@ describe('facepaint', () => {
 
   test('nested arrays', () => {
     const result = css(mq([[[[{ color: ['red', 'blue', 'darkorchid'] }]]]]))
-    expect(result).toMatchSnapshot()
     const tree = renderer.create(<div css={result}>Basic</div>).toJSON()
     expect(tree).toMatchSnapshot()
     expect(sheet).toMatchSnapshot()
@@ -70,7 +65,6 @@ describe('facepaint', () => {
         alignItems: 'center'
       })
     )
-    expect(result).toMatchSnapshot()
     const tree = renderer.create(<div css={result}>multiple</div>).toJSON()
     expect(tree).toMatchSnapshot()
     expect(sheet).toMatchSnapshot()
@@ -90,7 +84,6 @@ describe('facepaint', () => {
         }
       })
     )
-    expect(result).toMatchSnapshot()
     const tree = renderer
       .create(
         <div css={result}>
@@ -117,7 +110,6 @@ describe('facepaint', () => {
         }
       })
     )
-    expect(result).toMatchSnapshot()
     const tree = renderer
       .create(
         <div css={result}>
@@ -145,7 +137,6 @@ describe('facepaint', () => {
         ]
       })
     )
-    expect(result).toMatchSnapshot()
     const tree = renderer
       .create(
         <div css={result}>
@@ -177,7 +168,6 @@ describe('facepaint', () => {
         ]
       )
     )
-    expect(result).toMatchSnapshot()
     const tree = renderer
       .create(
         <div css={result}>


### PR DESCRIPTION
Closes #3 
Closes #6 

The reason for the issues above is that facepaint put all of the default styles into the root, Stylis puts all the declarations that are in the root into the same rule but they go in their own rule if they are in their own selector so this gives each default style the `&` selector. This will mean there will be more rules but there's no way to avoid that and have predictable composition so ¯\\\_(ツ)_/¯.

I think we should still probably have #7 for people that don't want default styles.