### PR TITLE
Enforce consistent ordering of props

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,10 @@ export default function(breakpoints, { literal, overlap } = {}) {
       return obj.map(flatten)
     }
 
-    return Object.keys(obj).reduce((slots, key) => {
+    const slots = {}
+    const objects = {}
+    const props = {}
+    Object.keys(obj).forEach(key => {
       // Check if value is an array, but skip if it looks like a selector.
       // key.indexOf('&') === 0
 
@@ -36,7 +39,7 @@ export default function(breakpoints, { literal, overlap } = {}) {
           prior = v
 
           if (index === 0 && !literal) {
-            slots[key] = v
+            props[key] = v
           } else if (slots[mq[index]] === undefined) {
             slots[mq[index]] = { [key]: v }
           } else {
@@ -44,12 +47,20 @@ export default function(breakpoints, { literal, overlap } = {}) {
           }
         })
       } else if (typeof item === 'object') {
-        slots[key] = flatten(item)
+        objects[key] = flatten(item)
       } else {
-        slots[key] = item
+        props[key] = item
       }
-      return slots
-    }, {})
+    })
+
+    // Ensure that all slots and then child objects are pushed to the end
+    mq.forEach(el => {
+      if (slots[el]) {
+        props[el] = slots[el];
+      }
+    })
+    Object.assign(props, objects)
+    return props
   }
 
   return (...values) => values.map(flatten)

--- a/test/__snapshots__/index.test.js.snap
+++ b/test/__snapshots__/index.test.js.snap
@@ -36,7 +36,7 @@ exports[`facepaint array values with selectors 1`] = `
 `;
 
 exports[`facepaint array values with selectors 2`] = `
-".css-1ot4erq .current-index {
+".css-j9a8v3 .current-index {
   color: blue;
   margin-right: 15px;
   display: none;
@@ -47,13 +47,13 @@ exports[`facepaint array values with selectors 2`] = `
 }
 
 @media (min-width:420px) {
-  .css-1ot4erq .current-index {
+  .css-j9a8v3 .current-index {
     color: red;
   }
 }
 
 @media (min-width:420px) {
-  .css-1ot4erq .current-index {
+  .css-j9a8v3 .current-index {
     display: block;
   }
 }"
@@ -136,6 +136,35 @@ exports[`facepaint boolean, null, and undefined values 2`] = `
   color: blue;
   color: red;
 }"
+`;
+
+exports[`facepaint complex overlapped 1`] = `
+Array [
+  Object {
+    "@media(min-width: 1120px)": Object {
+      "background": "darkorchid",
+      "color": "darkorchid",
+    },
+    "@media(min-width: 420px)": Object {
+      "background": "green",
+    },
+    "@media(min-width: 920px)": Object {
+      "color": "blue",
+    },
+    "background": "red",
+    "color": "red",
+  },
+]
+`;
+
+exports[`facepaint complex overlapped 2`] = `
+Array [
+  "color",
+  "background",
+  "@media(min-width: 420px)",
+  "@media(min-width: 920px)",
+  "@media(min-width: 1120px)",
+]
 `;
 
 exports[`facepaint composition 1`] = `
@@ -519,7 +548,7 @@ exports[`facepaint multiple 1`] = `
 `;
 
 exports[`facepaint multiple 2`] = `
-".css-egce6e {
+".css-1lsvhjc {
   color: red;
   display: -webkit-box;
   display: -webkit-flex;
@@ -533,21 +562,21 @@ exports[`facepaint multiple 2`] = `
 }
 
 @media (min-width:420px) {
-  .css-egce6e {
+  .css-1lsvhjc {
     color: green;
     display: block;
   }
 }
 
 @media (min-width:920px) {
-  .css-egce6e {
+  .css-1lsvhjc {
     color: blue;
     display: inline-block;
   }
 }
 
 @media (min-width:1120px) {
-  .css-egce6e {
+  .css-1lsvhjc {
     color: darkorchid;
     display: table;
   }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -247,4 +247,13 @@ describe('facepaint', () => {
     expect(tree).toMatchSnapshot()
     expect(sheet).toMatchSnapshot()
   })
+
+  test('complex overlapped', () => {
+    const result = mq({
+      color: ['red', 'red', 'blue', 'darkorchid'],
+      background: ['red', 'green', 'green', 'darkorchid']
+    })
+    expect(result).toMatchSnapshot()
+    expect(Object.keys(result[0])).toMatchSnapshot()
+  })
 })


### PR DESCRIPTION
Self props, slot permutations, then children objects

Avoid issue where arrays with holes may cause slots to be rendered in order other than defined in the breakpoints.